### PR TITLE
Remove rust installation from README

### DIFF
--- a/foundry/README.md
+++ b/foundry/README.md
@@ -6,13 +6,7 @@ This directory contains all the files necessary to deploy simplest ERC20-like co
 
 ## Prerequisites
 
-To use this project, Rust and Foundry must be installed on the machine.
-
-### Rust installation
-
-```sh
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-```
+To use this project, Foundry must be installed on the machine.
 
 ### Foundry installation
 


### PR DESCRIPTION
This PR removes the Rust installation instructions from the README.md, since Rust is installed with Foundry by default.