### PR TITLE
Update solidity version to the latest 0.8.26 in the Foundry example

### DIFF
--- a/foundry/script/TestERC20/DeployTestERC20.s.sol
+++ b/foundry/script/TestERC20/DeployTestERC20.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.26;
+pragma solidity ^0.8.26;
 
 import "../../lib/forge-std/src/Script.sol";
 import "../../src/TestERC20/TestERC20.sol";

--- a/foundry/script/TestERC20/DeployTestERC20.s.sol
+++ b/foundry/script/TestERC20/DeployTestERC20.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.21;
+pragma solidity >=0.8.26;
 
 import "../../lib/forge-std/src/Script.sol";
 import "../../src/TestERC20/TestERC20.sol";

--- a/foundry/script/TestERC20/MintTestERC20.s.sol
+++ b/foundry/script/TestERC20/MintTestERC20.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.26;
+pragma solidity ^0.8.26;
 
 import "../../lib/forge-std/src/Script.sol";
 import "../../src/TestERC20/TestERC20.sol";

--- a/foundry/script/TestERC20/MintTestERC20.s.sol
+++ b/foundry/script/TestERC20/MintTestERC20.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.21;
+pragma solidity >=0.8.26;
 
 import "../../lib/forge-std/src/Script.sol";
 import "../../src/TestERC20/TestERC20.sol";

--- a/foundry/src/TestERC20/TestERC20.sol
+++ b/foundry/src/TestERC20/TestERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.26;
+pragma solidity ^0.8.26;
 
 import "../../lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 import "../../lib/openzeppelin-contracts/contracts/access/Ownable.sol";

--- a/foundry/src/TestERC20/TestERC20.sol
+++ b/foundry/src/TestERC20/TestERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.21;
+pragma solidity >=0.8.26;
 
 import "../../lib/openzeppelin-contracts/contracts/token/ERC20/ERC20.sol";
 import "../../lib/openzeppelin-contracts/contracts/access/Ownable.sol";

--- a/foundry/test/TestERC20/TestERC20.t.sol
+++ b/foundry/test/TestERC20/TestERC20.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.21;
+pragma solidity >=0.8.26;
 
 import "../../lib/forge-std/src/Test.sol";
 import "../../src/TestERC20/TestERC20.sol";

--- a/foundry/test/TestERC20/TestERC20.t.sol
+++ b/foundry/test/TestERC20/TestERC20.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.26;
+pragma solidity ^0.8.26;
 
 import "../../lib/forge-std/src/Test.sol";
 import "../../src/TestERC20/TestERC20.sol";


### PR DESCRIPTION
This PR updates the latest solidity version `0.8.26` in the smart contracts, test scripts and deploy scripts in the Foundry tutorial.